### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,4 +1,6 @@
 name: Black
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/carlkidcrypto/purpleair_api/security/code-scanning/2](https://github.com/carlkidcrypto/purpleair_api/security/code-scanning/2)

To fix this problem, add an explicit `permissions` block to the workflow to restrict the permissions of the `GITHUB_TOKEN` to only those required. For this workflow, read-only access to repository contents (`contents: read`) is sufficient and is the minimum necessary privilege. Add the following block directly below the workflow `name:` so it applies to all jobs unless they have more specific permissions set. This change only affects the `.github/workflows/black.yml` file; no additional imports or changes are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
