### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_and_publish_to_test_pypi.yml
+++ b/.github/workflows/build_and_publish_to_test_pypi.yml
@@ -2,6 +2,8 @@
 # https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
 
 name: TestPyPI Distributions
+permissions:
+  contents: read
 concurrency: build_and_publish_to_test_pypi
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/carlkidcrypto/purpleair_api/security/code-scanning/3](https://github.com/carlkidcrypto/purpleair_api/security/code-scanning/3)

To fix this problem, we should explicitly set the `permissions` key within the workflow file. The most maintainable and safest way is to place the `permissions` block at the top level of the workflow (directly under `name` or `concurrency`), which applies the settings to all jobs unless a job overrides them. Based on the actions in use in this workflow, the minimal required permission is `contents: read`, as none of the steps require repository write access. This should be added just after the `name` and/or `concurrency` lines, before `on:`.

No changes are required in the jobs themselves. No additional dependencies or imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
