### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_and_publish_to_pypi.yml
+++ b/.github/workflows/build_and_publish_to_pypi.yml
@@ -2,6 +2,8 @@
 # https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
 
 name: PyPI Distributions
+permissions:
+  contents: read
 concurrency: build_and_publish_to_pypi
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/carlkidcrypto/purpleair_api/security/code-scanning/4](https://github.com/carlkidcrypto/purpleair_api/security/code-scanning/4)

To fix the problem, explicitly set the permissions for the workflow to grant only those needed for its tasks. In this case, since the workflow is building and publishing to PyPI (an external service), it likely only needs to be able to read repository content (for example, if it checks out code or reads files). Therefore, `contents: read` is the least privilege option. If, in the future, a step requires more (e.g., writing releases, updating PRs/issues), relevant permissions should be added selectively. 

In general, the fix is to add a top-level `permissions:` block near the top of the workflow file, outside of the `jobs:` section (to apply to all jobs), or inside the job if only that job needs it. The most common location is just below the `name:` and before `on:`. 

No imports or additional code are required to implement this fix; it is a YAML configuration edit.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
