### PR TITLE
Potential fix for code scanning alert no. 10: Clear-text logging of sensitive information

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -35,4 +35,4 @@ jobs:
     if: needs.check-source-changes.outputs.run_job == 'true'
     steps:
       - uses: actions/checkout@v4
-      - uses: psf/black@24.10.0
+      - uses: psf/black@25.9.0

--- a/purpleair_api/PurpleAirAPI.py
+++ b/purpleair_api/PurpleAirAPI.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 
 """
-    Copyright 2024 carlkidcrypto, All rights reserved.
-    A python3 class designed to fetch data from Purple Air's new API.
-    https://api.purpleair.com/#api-welcome
+Copyright 2024 carlkidcrypto, All rights reserved.
+A python3 class designed to fetch data from Purple Air's new API.
+https://api.purpleair.com/#api-welcome
 """
 
 from purpleair_api.PurpleAirAPIHelpers import debug_log, send_url_get_request
@@ -84,7 +84,9 @@ class PurpleAirAPI(PurpleAirReadAPI, PurpleAirWriteAPI, PurpleAirLocalAPI):
 
         # Avoid logging sensitive API keys in debug output
         debug_log(f"_api_versions contains {len(self._api_versions)} key(s)")
-        debug_log(f"_api_keys_last_checked contains {len(self._api_keys_last_checked)} key(s)")
+        debug_log(
+            f"_api_keys_last_checked contains {len(self._api_keys_last_checked)} key(s)"
+        )
         debug_log(f"_api_key_types contains {len(self._api_key_types)} key(s)")
         debug_log(your_ipv4_address)
 

--- a/purpleair_api/PurpleAirAPIConstants.py
+++ b/purpleair_api/PurpleAirAPIConstants.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
 """
-    Copyright 2024 carlkidcrypto, All rights reserved.
-    A python with constants with for use in PurpleAirAPI.py
+Copyright 2024 carlkidcrypto, All rights reserved.
+A python with constants with for use in PurpleAirAPI.py
 """
 
 #: A constant to see if debug statements are enabled in the PurpleAirAPI module.

--- a/purpleair_api/PurpleAirAPIError.py
+++ b/purpleair_api/PurpleAirAPIError.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 
 """
-    Copyright 2024 carlkidcrypto, All rights reserved.
-    A python3 class designed to fetch data from Purple Air's new API.
-    https://api.purpleair.com/#api-welcome
+Copyright 2024 carlkidcrypto, All rights reserved.
+A python3 class designed to fetch data from Purple Air's new API.
+https://api.purpleair.com/#api-welcome
 """
 
 

--- a/purpleair_api/PurpleAirAPIHelpers.py
+++ b/purpleair_api/PurpleAirAPIHelpers.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 
 """
-    Copyright 2024 carlkidcrypto, All rights reserved.
-    A python3 file containing helper functions for the PurpleAirAPI** files.
-    https://api.purpleair.com/#api-welcome
+Copyright 2024 carlkidcrypto, All rights reserved.
+A python3 file containing helper functions for the PurpleAirAPI** files.
+https://api.purpleair.com/#api-welcome
 """
 
 from purpleair_api.PurpleAirAPIConstants import (

--- a/purpleair_api/PurpleAirLocalAPI.py
+++ b/purpleair_api/PurpleAirLocalAPI.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 
 """
-    Copyright 2024 carlkidcrypto, All rights reserved.
-    A python3 class designed to fetch data from Purple Air's new API.
-    This class will handle all `local` requests
-    https://api.purpleair.com/#api-welcome
+Copyright 2024 carlkidcrypto, All rights reserved.
+A python3 class designed to fetch data from Purple Air's new API.
+This class will handle all `local` requests
+https://api.purpleair.com/#api-welcome
 """
 
 from purpleair_api.PurpleAirAPIError import PurpleAirAPIError

--- a/purpleair_api/PurpleAirReadAPI.py
+++ b/purpleair_api/PurpleAirReadAPI.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 
 """
-    Copyright 2024 carlkidcrypto, All rights reserved.
-    A python3 class designed to fetch data from Purple Air's new API.
-    This class will handle all `read` requests
-    https://api.purpleair.com/#api-welcome
+Copyright 2024 carlkidcrypto, All rights reserved.
+A python3 class designed to fetch data from Purple Air's new API.
+This class will handle all `read` requests
+https://api.purpleair.com/#api-welcome
 """
 
 from purpleair_api.PurpleAirAPIHelpers import send_url_get_request

--- a/purpleair_api/PurpleAirWriteAPI.py
+++ b/purpleair_api/PurpleAirWriteAPI.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 
 """
-    Copyright 2024 carlkidcrypto, All rights reserved.
-    A python3 class designed to fetch data from Purple Air's new API.
-    This class will handle all `write` requests
-    https://api.purpleair.com/#api-welcome
+Copyright 2024 carlkidcrypto, All rights reserved.
+A python3 class designed to fetch data from Purple Air's new API.
+This class will handle all `write` requests
+https://api.purpleair.com/#api-welcome
 """
 
 from purpleair_api.PurpleAirAPIError import PurpleAirAPIError

--- a/tests/test_purpleair_api.py
+++ b/tests/test_purpleair_api.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """
-    Copyright 2023 carlkidcrypto, All rights reserved.
+Copyright 2023 carlkidcrypto, All rights reserved.
 """
 
 

--- a/tests/test_purpleair_api_error.py
+++ b/tests/test_purpleair_api_error.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """
-    Copyright 2023 carlkidcrypto, All rights reserved.
+Copyright 2023 carlkidcrypto, All rights reserved.
 """
 
 

--- a/tests/test_purpleair_api_helpers.py
+++ b/tests/test_purpleair_api_helpers.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """
-    Copyright 2023 carlkidcrypto, All rights reserved.
+Copyright 2023 carlkidcrypto, All rights reserved.
 """
 
 

--- a/tests/test_purpleair_local_api.py
+++ b/tests/test_purpleair_local_api.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """
-    Copyright 2023 carlkidcrypto, All rights reserved.
+Copyright 2023 carlkidcrypto, All rights reserved.
 """
 
 

--- a/tests/test_purpleair_read_api.py
+++ b/tests/test_purpleair_read_api.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """
-    Copyright 2023 carlkidcrypto, All rights reserved.
+Copyright 2023 carlkidcrypto, All rights reserved.
 """
 
 

--- a/tests/test_purpleair_write_api.py
+++ b/tests/test_purpleair_write_api.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """
-    Copyright 2023 carlkidcrypto, All rights reserved.
+Copyright 2023 carlkidcrypto, All rights reserved.
 """
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/carlkidcrypto/purpleair_api/security/code-scanning/10](https://github.com/carlkidcrypto/purpleair_api/security/code-scanning/10)

To fix this, ensure that sensitive data (such as API keys, passwords, or other secret tokens) is never printed via `debug_log` or any other logging function. In this case, the problematic calls print internal dicts whose keys are API keys (`self._api_keys_last_checked`, `self._api_versions`, and `self._api_key_types`). The best fix is to avoid logging the entire dict or mask/obfuscate the keys before printing.

Specifically:
- In `PurpleAirAPI.py`'s `__init__`, replace the calls to `debug_log(self._api_versions)`, `debug_log(self._api_keys_last_checked)`, and `debug_log(self._api_key_types)` to avoid revealing API keys.
- Instead, log only the dictionary values or use fixed strings/metadata about their contents (such as their lengths, keys replaced with `***`, etc.), so no sensitive keys or values are disclosed.
- No change is needed in `PurpleAirAPIHelpers.py` itself, unless you want to add utility masking functions (but as per instructions, only change the snippets shown).

The required change:
- Edit lines 85–87 in `PurpleAirAPI.py` to safely print only non-sensitive information (such as the length of the dict, or an obfuscated version).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
