### PR TITLE
[docs-improvement] Fix typos, grammar, and misleading docstrings across documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,8 +64,8 @@ You can also install PurpleAir API by cloning down this repo:
 
 .. code-block:: bash
 
-   git clone https://github.com/carlkidcrypto/purple_air_api.git
-   cd purple_air_api
+   git clone https://github.com/carlkidcrypto/purpleair_api.git
+   cd purpleair_api
    python3 setup.py install
 
 PurpleAirAPI Usage Example

--- a/purpleair_api/PurpleAirAPIHelpers.py
+++ b/purpleair_api/PurpleAirAPIHelpers.py
@@ -47,14 +47,14 @@ def verify_request_status_codes(status_code) -> bool:
         return False
 
     else:
-        raise PurpleAirAPIError(f"Unkown status code - {status_code}!")
+        raise PurpleAirAPIError(f"Unknown status code - {status_code}!")
 
 
 def convert_requests_text_to_json(text=None) -> dict:
     """
     A helper to convert request.text to json.
 
-    :param str text: The request.txt to convert to json
+    :param str text: The request.text to convert to json
 
     :return dict
     """
@@ -156,10 +156,11 @@ def send_url_get_request(
 
 def send_url_post_request(request_url, api_key_to_use, json_post_parameters={}):
     """
-    A class helper to send the url request. It can also add onto the
-    'request_url' string if 'optional_parameters_dict' are provided.
+    A helper to send a POST request to the given URL.
 
-    :param str request_url: The constructed string url request string.
+    :param str request_url: The constructed URL request string.
+    :param str api_key_to_use: The API key to include in the request header.
+    :param dict json_post_parameters: Optional JSON body parameters to include in the request.
     """
 
     debug_log(request_url)
@@ -191,10 +192,11 @@ def send_url_post_request(request_url, api_key_to_use, json_post_parameters={}):
 
 def send_url_delete_request(request_url, api_key_to_use, json_post_parameters={}):
     """
-    A class helper to send the url request. It can also add onto the
-    'request_url' string if 'optional_parameters_dict' are provided.
+    A helper to send a DELETE request to the given URL.
 
-    :param str request_url: The constructed string url request string.
+    :param str request_url: The constructed URL request string.
+    :param str api_key_to_use: The API key to include in the request header.
+    :param dict json_post_parameters: Optional JSON body parameters to include in the request.
     """
 
     debug_log(request_url)

--- a/purpleair_api/PurpleAirLocalAPI.py
+++ b/purpleair_api/PurpleAirLocalAPI.py
@@ -20,7 +20,7 @@ class PurpleAirLocalAPI:
     """
 
     def __init__(self, ipv4_address_list=None):
-        # Create the vase API request string for local networks.
+        # Create the base API request string for local networks.
         error_msg = (
             "Must provide the IPv4 address list for the sensor(s) on your local network"
         )
@@ -43,7 +43,7 @@ class PurpleAirLocalAPI:
 
     def request_local_sensor_data(self) -> dict:
         """
-        A method to request a local sensors data. This sensor must be in a netork that is accessible
+        A method to request a local sensor's data. This sensor must be on a network that is accessible.
         """
 
         retval = {}

--- a/purpleair_api/PurpleAirReadAPI.py
+++ b/purpleair_api/PurpleAirReadAPI.py
@@ -355,7 +355,7 @@ class PurpleAirReadAPI:
         average=None,
     ):
         """
-        A method to get a members' historic data from a group to which said member belongs too.
+        A method to get a member's historic data from a group to which said member belongs.
 
         :param int group_id: Groups unique ID.
 
@@ -442,7 +442,7 @@ class PurpleAirReadAPI:
         selat=None,
     ):
         """
-        A method to get multiple members' data from from a group to which said members belong too.
+        A method to get multiple members' data from a group to which said members belong.
 
         :param int group_id: The group_id of the requested group. This group must be owned by the api_key.
 

--- a/sphinx_docs_build/source/index.rst
+++ b/sphinx_docs_build/source/index.rst
@@ -38,8 +38,8 @@ Install via pip::
 
 Or clone from GitHub::
 
-    git clone https://github.com/carlkidcrypto/purple_air_api.git
-    cd purple_air_api
+    git clone https://github.com/carlkidcrypto/purpleair_api.git
+    cd purpleair_api
     python3 setup.py install
 
 Quick Example


### PR DESCRIPTION
- PurpleAirLocalAPI.py: fix 'vase' -> 'base' comment typo and 'netork' -> 'network' docstring typo
- PurpleAirAPIHelpers.py: fix 'Unkown' -> 'Unknown' in error message, fix 'request.txt' -> 'request.text' in docstring, replace inaccurate copy-pasted docstrings for send_url_post_request and send_url_delete_request (they do not modify the URL like get does)
- PurpleAirReadAPI.py: fix 'from from' double word and 'belong too' -> 'belong to' grammar errors in method docstrings
- README.rst and sphinx_docs_build/source/index.rst: fix git clone URL from 'purple_air_api' to 'purpleair_api' (correct repo name)