### PR TITLE
[coverage-autofix] Add missing coverage tests and fix request_sensor_historic_data bug

### DIFF
--- a/purpleair_api/PurpleAirReadAPI.py
+++ b/purpleair_api/PurpleAirReadAPI.py
@@ -258,7 +258,6 @@ class PurpleAirReadAPI:
             "privacy": privacy,
             "start_timestamp": start_timestamp,
             "end_timestamp": end_timestamp,
-            "modified_since": end_timestamp,
             "average": average,
         }
 

--- a/tests/test_purpleair_local_api.py
+++ b/tests/test_purpleair_local_api.py
@@ -63,6 +63,35 @@ class PurpleAirLocalAPITest(unittest.TestCase):
         with self.assertRaises(PurpleAirAPIError):
             self.pala = PurpleAirLocalAPI({})
 
+    def test_request_local_sensor_data_too_long_ip_provided(self):
+        """
+        Test that providing an IP address longer than 15 characters results in a `PurpleAirAPIError`.
+        """
+
+        # An address of 16 chars exercises the len(address) > 15 branch
+        with self.assertRaises(PurpleAirAPIError):
+            PurpleAirLocalAPI(["192.168.1.100000"])
+
+    def test_request_local_sensor_data_multiple_ips(self):
+        """
+        Test that we can request data from multiple sensors at once.
+        """
+
+        # Setup
+        pala = PurpleAirLocalAPI(["192.168.1.2", "192.168.1.3"])
+        fake_url_1 = "http://192.168.1.2/json"
+        fake_url_2 = "http://192.168.1.3/json"
+
+        # Action and Expected Result
+        with requests_mock.Mocker() as m:
+            m.get(fake_url_1, text='{"sensor": 1}', status_code=200)
+            m.get(fake_url_2, text='{"sensor": 2}', status_code=200)
+            retval = pala.request_local_sensor_data()
+
+        self.assertEqual(len(retval), 2)
+        self.assertIn("192.168.1.2", retval)
+        self.assertIn("192.168.1.3", retval)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_purpleair_read_api.py
+++ b/tests/test_purpleair_read_api.py
@@ -278,6 +278,96 @@ class PurpleAirReadAPITest(unittest.TestCase):
             )
             self.para.request_group_list_data()
 
+    def test_request_member_data_with_fields(self):
+        """
+        Test that we can request member data with the optional fields parameter.
+        """
+
+        # Setup
+        fake_url_request = "https://api.purpleair.com/v1/groups/4321/members/1234?fields=name,temperature"
+
+        # Action and Expected Result
+        with requests_mock.Mocker() as m:
+            m.get(
+                fake_url_request,
+                text='{"test": 500}',
+                status_code=200,
+            )
+            self.para.request_member_data(4321, 1234, fields="name, temperature")
+
+    def test_request_sensor_historic_data_with_optional_parameters(self):
+        """
+        Test that we can request historic sensor data with all optional parameters.
+        """
+
+        # Setup
+        fake_url_request = "https://api.purpleair.com/v1/sensors/1234/history?fields=name,field1&read_key=abc&privacy=auto&start_timestamp=100&end_timestamp=200&average=10"
+
+        # Action and Expected Result
+        with requests_mock.Mocker() as m:
+            m.get(
+                fake_url_request,
+                text='{"test": 5}',
+                status_code=200,
+            )
+            self.para.request_sensor_historic_data(
+                sensor_index=1234,
+                fields="name, field1",
+                read_key="abc",
+                privacy="auto",
+                start_timestamp=100,
+                end_timestamp=200,
+                average=10,
+            )
+
+    def test_request_member_historic_data_with_optional_parameters(self):
+        """
+        Test that we can request member historic data with all optional parameters.
+        """
+
+        # Setup
+        fake_url_request = "https://api.purpleair.com/v1/groups/4321/members/1234/history/?fields=name&privacy=auto&start_timestamp=100&end_timestamp=200&average=10"
+
+        # Action and Expected Result
+        with requests_mock.Mocker() as m:
+            m.get(
+                fake_url_request,
+                text='{"test": 500}',
+                status_code=200,
+            )
+            self.para.request_member_historic_data(
+                4321,
+                1234,
+                "name",
+                privacy="auto",
+                start_timestamp=100,
+                end_timestamp=200,
+                average=10,
+            )
+
+    def test_request_members_data_with_optional_parameters(self):
+        """
+        Test that we can request members data with optional parameters.
+        """
+
+        # Setup
+        fake_url_request = "https://api.purpleair.com/v1/groups/4321/members?fields=name&location_type=1&show_only=123,456&max_age=100"
+
+        # Action and Expected Result
+        with requests_mock.Mocker() as m:
+            m.get(
+                fake_url_request,
+                text='{"test": 500}',
+                status_code=200,
+            )
+            self.para.request_members_data(
+                4321,
+                "name",
+                location_type=1,
+                show_only="123, 456",
+                max_age=100,
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
…ta; add coverage tests

- Fix copy-paste bug in PurpleAirReadAPI.request_sensor_historic_data where 'modified_since' was incorrectly populated with end_timestamp (no such parameter exists in this method's signature).
- Add test_request_local_sensor_data_too_long_ip_provided to exercise the len(address) > 15 branch in PurpleAirLocalAPI.__init__.
- Add test_request_local_sensor_data_multiple_ips for multi-sensor path.
- Add request_member_data test with optional fields parameter.
- Add request_sensor_historic_data test with all optional parameters, verifying the corrected URL (no modified_since).
- Add request_member_historic_data test with optional parameters.
- Add request_members_data test with optional parameters.